### PR TITLE
fix linux docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.4'
 services:
 
   deadline-db:


### PR DESCRIPTION
linux needs at least 3.4 in the docker compose file to targets to work